### PR TITLE
Disable lcd undervolt on anzu

### DIFF
--- a/arch/arm/mach-msm/board-semc_mogami.c
+++ b/arch/arm/mach-msm/board-semc_mogami.c
@@ -2030,7 +2030,11 @@ static struct sii9024_platform_data sii9024_platform_data = {
 static void semc_mogami_lcd_regulators_on(void)
 {
 	vreg_helper_on("gp7",1800);  /* L8 */
+#ifdef CONFIG_MACH_SEMC_ANZU
+	vreg_helper_on("gp6",2850);  /* L15 */
+#else
 	vreg_helper_on("gp6",2300);  /* L15 */
+#endif
 }
 
 /* Generic Power On function for SEMC mogami displays */
@@ -4376,7 +4380,11 @@ static void __init shared_vreg_on(void)
 {
 	vreg_helper_on(VREG_L20, 2800);
 	vreg_helper_on(VREG_L10, 2600);
+#ifdef CONFIG_MACH_SEMC_ANZU
+	vreg_helper_on(VREG_L15, 2900);
+#else
 	vreg_helper_on(VREG_L15, 2300);
+#endif
 	vreg_helper_on(VREG_L8, 1800);
 }
 


### PR DESCRIPTION
anzu display does not like undervolting,
it's causing abnormal lcd contrast & saturation

Signed-off-by: Michael Bestas mikeioannina@gmail.com

Change-Id: Icee29b19e6b8d41daaa4b79d821d73092d9af8c9
